### PR TITLE
Rails 6 compatibility

### DIFF
--- a/noticent.gemspec
+++ b/noticent.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~> 5.2"
-  spec.add_dependency "activesupport", "~> 5.2"
-  spec.add_dependency "actionpack", "~> 5.2"
+  spec.add_dependency "activerecord", ">= 5.2"
+  spec.add_dependency "activesupport", ">= 5.2"
+  spec.add_dependency "actionpack", ">= 5.2"
 
   spec.add_development_dependency "combustion", "~> 1.1"
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
Replaced twiddle wakka with >= to make gem compatible with Rails 6

Note that I am not sure how to test this. But this does what you asked in #5 -- fork and bump the version. I'm happy to help test but I don't have in-depth knowledge of this gem (yet).